### PR TITLE
Fix incorrect transforms in gltf2ozz

### DIFF
--- a/src/animation/offline/gltf/gltf2ozz.cc
+++ b/src/animation/offline/gltf/gltf2ozz.cc
@@ -362,12 +362,35 @@ CreateTranslationRestPoseKey(const tinygltf::Node& _node) {
   ozz::animation::offline::RawAnimation::TranslationKey key;
   key.time = 0.0f;
 
-  if (_node.translation.empty()) {
-    key.value = ozz::math::Float3::zero();
-  } else {
+  if (!_node.translation.empty()) {
     key.value = ozz::math::Float3(static_cast<float>(_node.translation[0]),
                                   static_cast<float>(_node.translation[1]),
                                   static_cast<float>(_node.translation[2]));
+  } else if (_node.matrix.empty()) {
+    // Extract translation from the matrix
+    const ozz::math::Float4x4 matrix = {
+        {ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[0]),
+                                      static_cast<float>(_node.matrix[1]),
+                                      static_cast<float>(_node.matrix[2]),
+                                      static_cast<float>(_node.matrix[3])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[4]),
+                                      static_cast<float>(_node.matrix[5]),
+                                      static_cast<float>(_node.matrix[6]),
+                                      static_cast<float>(_node.matrix[7])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[8]),
+                                      static_cast<float>(_node.matrix[9]),
+                                      static_cast<float>(_node.matrix[10]),
+                                      static_cast<float>(_node.matrix[11])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[12]),
+                                      static_cast<float>(_node.matrix[13]),
+                                      static_cast<float>(_node.matrix[14]),
+                                      static_cast<float>(_node.matrix[15]))}};
+    ozz::math::SimdFloat4 translation, rotation, scale;
+    if (ToAffine(matrix, &translation, &rotation, &scale)) {
+      ozz::math::Store3PtrU(translation, &key.value.x);
+    }
+  } else {
+    key.value = ozz::math::Float3::zero();
   }
 
   return key;
@@ -378,13 +401,36 @@ ozz::animation::offline::RawAnimation::RotationKey CreateRotationRestPoseKey(
   ozz::animation::offline::RawAnimation::RotationKey key;
   key.time = 0.0f;
 
-  if (_node.rotation.empty()) {
-    key.value = ozz::math::Quaternion::identity();
-  } else {
+  if (!_node.rotation.empty()) {
     key.value = ozz::math::Quaternion(static_cast<float>(_node.rotation[0]),
                                       static_cast<float>(_node.rotation[1]),
                                       static_cast<float>(_node.rotation[2]),
                                       static_cast<float>(_node.rotation[3]));
+  } else if (_node.matrix.empty()) {
+    // Extract rotation from the matrix
+    const ozz::math::Float4x4 matrix = {
+        {ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[0]),
+                                      static_cast<float>(_node.matrix[1]),
+                                      static_cast<float>(_node.matrix[2]),
+                                      static_cast<float>(_node.matrix[3])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[4]),
+                                      static_cast<float>(_node.matrix[5]),
+                                      static_cast<float>(_node.matrix[6]),
+                                      static_cast<float>(_node.matrix[7])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[8]),
+                                      static_cast<float>(_node.matrix[9]),
+                                      static_cast<float>(_node.matrix[10]),
+                                      static_cast<float>(_node.matrix[11])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[12]),
+                                      static_cast<float>(_node.matrix[13]),
+                                      static_cast<float>(_node.matrix[14]),
+                                      static_cast<float>(_node.matrix[15]))}};
+    ozz::math::SimdFloat4 translation, rotation, scale;
+    if (ToAffine(matrix, &translation, &rotation, &scale)) {
+      ozz::math::StorePtrU(rotation, &key.value.x);
+    }
+  } else {
+    key.value = ozz::math::Quaternion::identity();
   }
   return key;
 }
@@ -394,12 +440,35 @@ ozz::animation::offline::RawAnimation::ScaleKey CreateScaleRestPoseKey(
   ozz::animation::offline::RawAnimation::ScaleKey key;
   key.time = 0.0f;
 
-  if (_node.scale.empty()) {
-    key.value = ozz::math::Float3::one();
-  } else {
+  if (!_node.scale.empty()) {
     key.value = ozz::math::Float3(static_cast<float>(_node.scale[0]),
                                   static_cast<float>(_node.scale[1]),
                                   static_cast<float>(_node.scale[2]));
+  } else if (_node.matrix.empty()) {
+    // Extract scale from the matrix
+    const ozz::math::Float4x4 matrix = {
+        {ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[0]),
+                                      static_cast<float>(_node.matrix[1]),
+                                      static_cast<float>(_node.matrix[2]),
+                                      static_cast<float>(_node.matrix[3])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[4]),
+                                      static_cast<float>(_node.matrix[5]),
+                                      static_cast<float>(_node.matrix[6]),
+                                      static_cast<float>(_node.matrix[7])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[8]),
+                                      static_cast<float>(_node.matrix[9]),
+                                      static_cast<float>(_node.matrix[10]),
+                                      static_cast<float>(_node.matrix[11])),
+         ozz::math::simd_float4::Load(static_cast<float>(_node.matrix[12]),
+                                      static_cast<float>(_node.matrix[13]),
+                                      static_cast<float>(_node.matrix[14]),
+                                      static_cast<float>(_node.matrix[15]))}};
+    ozz::math::SimdFloat4 translation, rotation, scale;
+    if (ToAffine(matrix, &translation, &rotation, &scale)) {
+      ozz::math::Store3PtrU(scale, &key.value.x);
+    }
+  } else {
+    key.value = ozz::math::Float3::one();
   }
   return key;
 }


### PR DESCRIPTION
Since gltf2ozz considers the entire scene graph as a skeleton if no skins are defined in the glTF file, we can encounter (non-animated) nodes using `matrix` instead of `translation`, `rotation` and `scale` for their transformations while parsing all nodes. These were considered "without a transform", leading to incorrect results.

An example of this behavior can be seen, if you have a glTF viewer using ozz-animation, on the following model: https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/VC.

Importing the VC model in Blender and exporting it without making any changes fortunately replaces all matrices with translations, rotations and scales, which allows for an easy comparison.